### PR TITLE
Great basin biome missing

### DIFF
--- a/GameData/BeyondHome/Configs/Rhode.cfg
+++ b/GameData/BeyondHome/Configs/Rhode.cfg
@@ -98,7 +98,7 @@
 					name = Great Basin
 					displayName = Great Basin
 					value = 1.25
-					color = C68163
+					color = #C68163
 				}
 			}
         }


### PR DESCRIPTION
Fix 'great basin' biome definition in Rhode config.